### PR TITLE
update ocaml version (4.05 to 4.07), pin-down mirage version (3.5 to 3.4)

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,8 +1,8 @@
 MIRAGE_KERNEL_NAME = qubes_firewall.xen
-#SOURCE_BUILD_DEP := ssh-agent-build-dep
-OCAML_VERSION ?= 4.05.0
+SOURCE_BUILD_DEP := mfw-build-dep
+OCAML_VERSION ?= 4.07.1
 
-#ssh-agent-build-dep:
-#	opam pin -y add angstrom https://github.com/reynir/angstrom.git#no-c-blit
+mfw-build-dep:
+  opam pin -y add mirage 3.4.0
 #	opam pin -y add ssh-agent https://github.com/reynir/ocaml-ssh-agent.git
 


### PR DESCRIPTION
not sure there is a better/official fix than pinning mirage down from 3.5 to 3.4, but that (3.4) is what the official docker builds use (and i cant figure out why) and now it works again under qubes-builder.

there is an example config (with mini-howto at the top) now too: https://github.com/QubesOS/qubes-builder/blob/master/example-configs/mirage.conf