### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ocaml/opam2@sha256:f7125924dd6632099ff98b2505536fe5f5c36bf0beb24779431bb62b
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN git fetch origin && git reset --hard 55e835f197d5a6961ff9b22eb5bbcb5a17f13e65 && opam update
+RUN git fetch origin && git reset --hard c261c4ee9c1ef032af93483913b60f674d4acdb2 && opam update
 
 RUN sudo apt-get install -y m4 libxen-dev pkg-config
 RUN opam install -y vchan xen-gnt mirage-xen-ocaml mirage-xen-minios io-page mirage-xen mirage mirage-nat mirage-qubes

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,8 +1,2 @@
 MIRAGE_KERNEL_NAME = qubes_firewall.xen
-SOURCE_BUILD_DEP := mfw-build-dep
 OCAML_VERSION ?= 4.07.1
-
-mfw-build-dep:
-  opam pin -y add mirage 3.4.0
-#	opam pin -y add ssh-agent https://github.com/reynir/ocaml-ssh-agent.git
-

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: addeb78681d73ee44df328ca059f6f15b8b7bbdff38a3de5363229cdf3da2eda"
+echo "SHA2 last known: 1f72adad30cbd4f8315983240bd150811084cb93d360c14740fadb36394c7aa8"
 echo "(hashes should match for released versions)"

--- a/config.ml
+++ b/config.ml
@@ -18,7 +18,7 @@ let main =
   foreign
     ~keys:[Functoria_key.abstract table_size]
     ~packages:[
-      package "vchan";
+      package "vchan" ~min:"4.0.2";
       package "cstruct";
       package "astring";
       package "tcpip" ~min:"3.7.0";
@@ -27,8 +27,8 @@ let main =
       package "ethernet";
       package "mirage-protocols";
       package "shared-memory-ring" ~min:"3.0.0";
-      package "netchannel" ~min:"1.8.0";
-      package "mirage-net-xen" ~min:"1.7.1";
+      package "netchannel" ~min:"1.10.2";
+      package "mirage-net-xen";
       package "ipaddr" ~min:"3.0.0";
       package "mirage-qubes";
       package "mirage-nat" ~min:"1.1.0";


### PR DESCRIPTION
Remove pin on mirage 3.4 - it should now be working with the latest release (untested - @xaki23: does this work for you now?).