### PR TITLE
Use source date in .tar.bz2 archive

### DIFF
--- a/Makefile.user
+++ b/Makefile.user
@@ -3,5 +3,5 @@ tar: build
 	mkdir _build/mirage-firewall
 	cp qubes_firewall.xen _build/mirage-firewall/vmlinuz
 	touch _build/mirage-firewall/modules.img
-	cat /dev/null | gzip > _build/mirage-firewall/initramfs
-	tar cjf mirage-firewall.tar.bz2 -C _build mirage-firewall
+	cat /dev/null | gzip -n > _build/mirage-firewall/initramfs
+	tar cjf mirage-firewall.tar.bz2 -C _build --mtime=./build-with-docker.sh mirage-firewall


### PR DESCRIPTION
All files are now added using the date the build-with-docker script was last changed. Since this includes the hash of the result, it should be up-to-date. This ensures that rebuilding the archive doesn't change it in any way.

Fixes #19 