### PR TITLE
 Wait if dom0 is slow to set the network configuration

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -31,7 +31,7 @@ let main =
       package "mirage-net-xen";
       package "ipaddr" ~min:"3.0.0";
       package "mirage-qubes";
-      package "mirage-nat" ~min:"1.1.0";
+      package "mirage-nat" ~min:"1.2.0";
       package "mirage-logs";
     ]
     "Unikernel.Main" (mclock @-> job)

--- a/dao.mli
+++ b/dao.mli
@@ -26,6 +26,8 @@ type network_config = {
   clients_our_ip : Ipaddr.V4.t;        (* The IP address of our interface to our client VMs (their gateway) *)
 }
 
-val read_network_config : Qubes.DB.t -> network_config
+val read_network_config : Qubes.DB.t -> network_config Lwt.t
+(** [read_network_config db] fetches the configuration from QubesDB.
+    If it isn't there yet, it waits until it is. *)
 
 val set_iptables_error : Qubes.DB.t -> string -> unit Lwt.t

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -13,7 +13,7 @@ module Main (Clock : Mirage_clock_lwt.MCLOCK) = struct
   (* Set up networking and listen for incoming packets. *)
   let network ~clock nat qubesDB =
     (* Read configuration from QubesDB *)
-    let config = Dao.read_network_config qubesDB in
+    Dao.read_network_config qubesDB >>= fun config ->
     (* Initialise connection to NetVM *)
     Uplink.connect ~clock config >>= fun uplink ->
     (* Report success *)


### PR DESCRIPTION
If the firewall boots too quickly, it seems it can fail with:

```
ERR [application] main: (Failure "QubesDB key \"/qubes-ip\" not present")
```

A similar thing also happens if you haven't configured a NetVM, or didn't configure the firewall as a proxy. Now we just log a warning and wait until things improve.

Also, I updated the mirage-nat minimum version to make sure `ping` works.