### PR TITLE
Fix ln(1) call in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [Deploy](#deploy) section below for installation instructions.
 Create a new Fedora-29 AppVM (or reuse an existing one). Open a terminal.
 Clone this Git repository and run the `build-with-docker.sh` script:
 
-    sudo ln -s /var/lib/docker /home/user/docker
+    sudo ln -s /home/user/docker /var/lib/docker
     sudo dnf install docker
     sudo systemctl start docker
     git clone https://github.com/mirage/qubes-mirage-firewall.git


### PR DESCRIPTION
The arguments were backwards. [```ln``` takes the link target first, then the link name](https://linux.die.net/man/1/ln).