### PR TITLE
Remove netchannel pin

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: b4758e0911acd25c278c5d4bb9feb05daccb5e3d6c3692b5e2274b098971e1b8"
+echo "SHA2 last known: 9f7d064a194be07301173389a4414266cd5d7ef935b16ed29a978a33cb92884c"
 echo "(hashes should match for released versions)"

--- a/config.ml
+++ b/config.ml
@@ -27,7 +27,7 @@ let main =
       package "ethernet";
       package "mirage-protocols";
       package "shared-memory-ring" ~min:"3.0.0";
-      package "netchannel" ~min:"1.11.0" ~pin:"git+https://github.com/mirage/mirage-net-xen.git";
+      package "netchannel" ~min:"1.11.0";
       package "mirage-net-xen";
       package "ipaddr" ~min:"3.0.0";
       package "mirage-qubes";


### PR DESCRIPTION
Version 1.11.0 has been released now, and the current trunk doesn't build without updating other things. The error was:

    File "lib/xenstore.ml", line 165, characters 19-34:
    Error: The module OS is an alias for module Os_xen, which is missing
        ocamlopt lib/.netchannel.objs/native/netchannel__Backend.{cmx,o} (exit 2)
    (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -g -I lib/.netchannel.objs/byte -I lib/.netchannel.objs/native -I /home/opam/.opam/4.07/lib/base/caml -I /home/opam/.opam/4.07/lib/bigarray-compat -I /home/opam/.opam/4.07/lib/bytes -I /home/opam/.opam/4.07/lib/cstruct -I /home/opam/.opam/4.07/lib/fmt -I /home/opam/.opam/4.07/lib/io-page -I /home/opam/.opam/4.07/lib/io-page-x[...]
    File "lib/backend.ml", line 23, characters 16-29:
    Error: The module OS is an alias for module Os_xen, which is missing

Reported by ronpunz in https://groups.google.com/forum/#!topic/qubes-users/PsYUXvypPDs