### PR TITLE
Upstream updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ script:
   - echo 'ADD . /home/opam/qubes-mirage-firewall' >> Dockerfile
   - echo 'RUN sudo chown -R opam /home/opam/qubes-mirage-firewall' >> Dockerfile
   - docker build -t qubes-mirage-firewall .
-  - docker run --rm -i qubes-mirage-firewall
+  - docker run --name build -i qubes-mirage-firewall
+  - docker cp build:/home/opam/qubes-mirage-firewall/qubes_firewall.xen .
+  - sha256sum qubes_firewall.xen
 sudo: required
 dist: trusty

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM ocaml/opam2@sha256:74fb6e30a95e1569db755b3c061970a8270dfc281c4e69bffe2cf990
 RUN git fetch origin && git reset --hard 3389beb33b37da54c9f5a41f19291883dfb59bfb && opam update
 
 RUN sudo apt-get install -y m4 libxen-dev pkg-config
-RUN opam install -y vchan mirage-xen-ocaml mirage-xen-minios io-page mirage-xen mirage mirage-nat mirage-qubes
+RUN opam install -y mirage lwt
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM ocaml/opam2@sha256:74fb6e30a95e1569db755b3c061970a8270dfc281c4e69bffe2cf990
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN git fetch origin && git reset --hard d28fedaa8a077a429bd7bd79cbc19eb90e01c040 && opam update
+RUN git fetch origin && git reset --hard 3389beb33b37da54c9f5a41f19291883dfb59bfb && opam update
 
 RUN sudo apt-get install -y m4 libxen-dev pkg-config
 RUN opam install -y vchan mirage-xen-ocaml mirage-xen-minios io-page mirage-xen mirage mirage-nat mirage-qubes

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,2 +1,2 @@
 MIRAGE_KERNEL_NAME = qubes_firewall.xen
-OCAML_VERSION ?= 4.07.1
+OCAML_VERSION ?= 4.08.0

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See the [Deploy](#deploy) section below for installation instructions.
 Create a new Fedora-29 AppVM (or reuse an existing one). Open a terminal.
 Clone this Git repository and run the `build-with-docker.sh` script:
 
+    mkdir /home/user/docker
     sudo ln -s /home/user/docker /var/lib/docker
     sudo dnf install docker
     sudo systemctl start docker

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: 9f7d064a194be07301173389a4414266cd5d7ef935b16ed29a978a33cb92884c"
+echo "SHA2 last known: 5707d97d78eb54cad9bade5322c197d8b3706335aa277ccad31fceac564f3319"
 echo "(hashes should match for released versions)"

--- a/client_eth.ml
+++ b/client_eth.ml
@@ -70,7 +70,7 @@ module ARP = struct
 
   let lookup t ip =
     if ip = t.net.client_gw then Some t.client_link#my_mac
-    else if (Ipaddr.V4.to_bytes ip).[3] = '\x01' then (
+    else if (Ipaddr.V4.to_octets ip).[3] = '\x01' then (
       Log.info (fun f -> f ~header:t.client_link#log_header
                    "Request for %a is invalid, but pretending it's me (see Qubes issue #5022)" Ipaddr.V4.pp ip);
       Some t.client_link#my_mac

--- a/config.ml
+++ b/config.ml
@@ -29,7 +29,7 @@ let main =
       package "shared-memory-ring" ~min:"3.0.0";
       package "netchannel" ~min:"1.11.0";
       package "mirage-net-xen";
-      package "ipaddr" ~min:"3.0.0";
+      package "ipaddr" ~min:"4.0.0";
       package "mirage-qubes";
       package "mirage-nat" ~min:"1.2.0";
       package "mirage-logs";


### PR DESCRIPTION
A slightly modified version of #74:

- Squashed ipaddr changes into one commit.
- Capitalised log messages, for consistency with other commits.
- Modified Dockerfile to avoid installing and then downgrading packages.
- Modified Travis script to show build's sha256.

@xaki23 : I skipped the README change for now. It's probably correct, but I didn't understand the commit message:

> actualy create the symlink-redirected docker dir so the installer wont remove the dangling symlink

What installer is this?