### PR TITLE
Mirage-xen >= 4.0.0

### DIFF
--- a/client_net.ml
+++ b/client_net.ml
@@ -4,7 +4,7 @@
 open Lwt.Infix
 open Fw_utils
 
-module Netback = Netchannel.Backend.Make(Netchannel.Xenstore.Make(OS.Xs))
+module Netback = Netchannel.Backend.Make(Netchannel.Xenstore.Make(Os_xen.Xs))
 module ClientEth = Ethernet.Make(Netback)
 
 let src = Logs.Src.create "client_net" ~doc:"Client networking"

--- a/config.ml
+++ b/config.ml
@@ -28,6 +28,7 @@ let main =
       package "mirage-protocols";
       package "shared-memory-ring" ~min:"3.0.0";
       package "netchannel" ~min:"1.11.0";
+      package "mirage-xen" ~min:"4.0.0";
       package "mirage-net-xen";
       package "ipaddr" ~min:"4.0.0";
       package "mirage-qubes";

--- a/dao.ml
+++ b/dao.ml
@@ -30,7 +30,7 @@ module VifMap = struct
 end
 
 let directory ~handle dir =
-  OS.Xs.directory handle dir >|= function
+  Os_xen.Xs.directory handle dir >|= function
   | [""] -> []      (* XenStore client bug *)
   | items -> items
 
@@ -46,7 +46,7 @@ let vifs ~handle domid =
         | Some device_id ->
         let vif = { ClientVif.domid; device_id } in
         Lwt.try_bind
-          (fun () -> OS.Xs.read handle (Printf.sprintf "%s/%d/ip" path device_id))
+          (fun () -> Os_xen.Xs.read handle (Printf.sprintf "%s/%d/ip" path device_id))
           (fun client_ip ->
              let client_ip = Ipaddr.V4.of_string_exn client_ip in
              Lwt.return (Some (vif, client_ip))
@@ -61,10 +61,10 @@ let vifs ~handle domid =
       )
 
 let watch_clients fn =
-  OS.Xs.make () >>= fun xs ->
+  Os_xen.Xs.make () >>= fun xs ->
   let backend_vifs = "backend/vif" in
   Log.info (fun f -> f "Watching %s" backend_vifs);
-  OS.Xs.wait xs (fun handle ->
+  Os_xen.Xs.wait xs (fun handle ->
     begin Lwt.catch
       (fun () -> directory ~handle backend_vifs)
       (function


### PR DESCRIPTION
These changes are required for mirage-xen >= 4.0.0.

See also https://github.com/mirage/mirage/pull/995 since it's making mirage put a mirage-xen < 4.0.0 constraint.