### PR TITLE
Add an upper bound for mirage-xen

### DIFF
--- a/config.ml
+++ b/config.ml
@@ -28,6 +28,7 @@ let main =
       package "mirage-protocols";
       package "shared-memory-ring" ~min:"3.0.0";
       package "netchannel" ~min:"1.11.0";
+      package "mirage-xen" ~max:"4.0.0";
       package "mirage-net-xen";
       package "ipaddr" ~min:"4.0.0";
       package "mirage-qubes";


### PR DESCRIPTION
We use features from mirage-xen not in mirage-xen >= 4.0.0.

Related to #76, and https://github.com/mirage/mirage/pull/995 will likely break qubes-mirage-firewall.