### PR TITLE
Fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ main.native
 mir-qubes-test
 qubes-firewall.xl.in
 qubes-firewall_libvirt.xml
+.merlin

--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,0 @@
-S .
-B _build
-PKG vchan.xen lwt mirage mirage-net-xen tcpip mirage-nat

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # It will probably still work on newer images, though, unless Debian
 # changes some compiler optimisations (unlikely).
 #FROM ocurrent/opam:alpine-3.10-ocaml-4.08
-FROM ocurrent/opam@sha256:4cf6f8a427e7f65a250cd5dbc9f5069e8f8213467376af5136bf67a21d39d6ec
+FROM ocurrent/opam@sha256:3f3ce7e577a94942c7f9c63cbdd1ecbfe0ea793f581f69047f3155967bba36f6
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard a83bd077e4e54c41b0664a2e1618670d57b7c79d && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 5eed470abc5c7991e448c9653698c03d6ea146d1 && opam update
 
-RUN opam depext -i -y mirage lwt
+RUN opam depext -i -y mirage.3.5.2 lwt
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: 3cf9358df911c7bc5a28846087c5359e5b550e5d0c6cf342a6e1c90545518ac6"
+echo "SHA2 last known: cae3c66d38a50671f694cd529062c538592438b95935d707b97d80b57fbfc186"
 echo "(hashes should match for released versions)"


### PR DESCRIPTION
- A new ocaml-migrate-parsetree.1.4.0 was released, replacing the old 1.4.0 with new code. This was rejected by the checksum test. Fixed by updating to the latest opam-repository. See: https://github.com/ocaml/opam-repository/pull/15294

- The latest opam-repository pulls in mirage 3.7, which doesn't work (`No available version of mirage-clock satisfies the constraints`), so pin the previous mirage 3.5.2 version instead.

- Mirage now generates `.merlin`, so remove it from Git.