### PR TITLE
pin mirage to 3.5.2 for qubes-builder builds

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,2 +1,7 @@
 MIRAGE_KERNEL_NAME = qubes_firewall.xen
 OCAML_VERSION ?= 4.08.1
+SOURCE_BUILD_DEP := firewall-build-dep
+
+firewall-build-dep:
+	opam pin -y add mirage 3.5.2
+


### PR DESCRIPTION
(required just as for the docker build)