### PR TITLE
support Mirage 3.7 and mirage-nat 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ FROM ocurrent/opam@sha256:3f3ce7e577a94942c7f9c63cbdd1ecbfe0ea793f581f69047f3155
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 5eed470abc5c7991e448c9653698c03d6ea146d1 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard d205c265cee9a86869259180fd2238da98370430 && opam update
 
-RUN opam depext -i -y mirage.3.5.2 lwt
+RUN opam depext -i -y mirage.3.7.4 lwt
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: cae3c66d38a50671f694cd529062c538592438b95935d707b97d80b57fbfc186"
+echo "SHA2 last known: 8a337e61e7d093f7c1f0fa5fe277dace4d606bfa06cfde3f2d61d6bdee6eefbc"
 echo "(hashes should match for released versions)"

--- a/client_net.ml
+++ b/client_net.ml
@@ -4,7 +4,7 @@
 open Lwt.Infix
 open Fw_utils
 
-module Netback = Netchannel.Backend.Make(Netchannel.Xenstore.Make(Os_xen.Xs))
+module Netback = Netchannel.Backend.Make(Netchannel.Xenstore.Make(OS.Xs))
 module ClientEth = Ethernet.Make(Netback)
 
 let src = Logs.Src.create "client_net" ~doc:"Client networking"

--- a/client_net.mli
+++ b/client_net.mli
@@ -3,8 +3,8 @@
 
 (** Handling client VMs. *)
 
-val listen : Router.t -> 'a Lwt.t
-(** [listen router] is a thread that watches for clients being added to and
-    removed from XenStore. Clients are connected to the client network and
-    packets are sent via [router]. We ensure the source IP address is correct
-    before routing a packet. *)
+val listen : (unit -> int64) -> Router.t -> 'a Lwt.t
+(** [listen get_timestamp router] is a thread that watches for clients being
+    added to and removed from XenStore. Clients are connected to the client
+    network and packets are sent via [router]. We ensure the source IP address
+    is correct before routing a packet. *)

--- a/config.ml
+++ b/config.ml
@@ -30,8 +30,8 @@ let main =
       package "netchannel" ~min:"1.11.0";
       package "mirage-net-xen";
       package "ipaddr" ~min:"4.0.0";
-      package "mirage-qubes";
-      package "mirage-nat" ~min:"1.2.0";
+      package "mirage-qubes" ~min:"0.8.0";
+      package "mirage-nat" ~min:"2.0.0";
       package "mirage-logs";
       package "mirage-xen" ~min:"5.0.0";
     ]

--- a/config.ml
+++ b/config.ml
@@ -33,7 +33,7 @@ let main =
       package "mirage-qubes";
       package "mirage-nat" ~min:"1.2.0";
       package "mirage-logs";
-      package "mirage-xen" ~min:"4.0.0";
+      package "mirage-xen" ~min:"5.0.0";
     ]
     "Unikernel.Main" (mclock @-> job)
 

--- a/dao.ml
+++ b/dao.ml
@@ -3,7 +3,6 @@
 
 open Lwt.Infix
 open Qubes
-open Fw_utils
 open Astring
 
 let src = Logs.Src.create "dao" ~doc:"QubesDB data access"
@@ -68,13 +67,13 @@ let watch_clients fn =
     begin Lwt.catch
       (fun () -> directory ~handle backend_vifs)
       (function
-        | Xs_protocol.Enoent _ -> return []
-        | ex -> fail ex)
+        | Xs_protocol.Enoent _ -> Lwt.return []
+        | ex -> Lwt.fail ex)
     end >>= fun items ->
     Lwt_list.map_p (vifs ~handle) items >>= fun items ->
     fn (List.concat items |> VifMap.of_list);
     (* Wait for further updates *)
-    fail Xs_protocol.Eagain
+    Lwt.fail Xs_protocol.Eagain
   )
 
 type network_config = {

--- a/dao.ml
+++ b/dao.ml
@@ -30,7 +30,7 @@ module VifMap = struct
 end
 
 let directory ~handle dir =
-  Os_xen.Xs.directory handle dir >|= function
+  OS.Xs.directory handle dir >|= function
   | [""] -> []      (* XenStore client bug *)
   | items -> items
 
@@ -46,7 +46,7 @@ let vifs ~handle domid =
         | Some device_id ->
         let vif = { ClientVif.domid; device_id } in
         Lwt.try_bind
-          (fun () -> Os_xen.Xs.read handle (Printf.sprintf "%s/%d/ip" path device_id))
+          (fun () -> OS.Xs.read handle (Printf.sprintf "%s/%d/ip" path device_id))
           (fun client_ip ->
              let client_ip = Ipaddr.V4.of_string_exn client_ip in
              Lwt.return (Some (vif, client_ip))
@@ -61,10 +61,10 @@ let vifs ~handle domid =
       )
 
 let watch_clients fn =
-  Os_xen.Xs.make () >>= fun xs ->
+  OS.Xs.make () >>= fun xs ->
   let backend_vifs = "backend/vif" in
   Log.info (fun f -> f "Watching %s" backend_vifs);
-  Os_xen.Xs.wait xs (fun handle ->
+  OS.Xs.wait xs (fun handle ->
     begin Lwt.catch
       (fun () -> directory ~handle backend_vifs)
       (function

--- a/fw_utils.ml
+++ b/fw_utils.ml
@@ -41,9 +41,6 @@ let error fmt =
   let err s = Failure s in
   Printf.ksprintf err fmt
 
-let return = Lwt.return
-let fail = Lwt.fail
-
 let or_raise msg pp = function
   | Ok x -> x
   | Error e -> failwith (Fmt.strf "%s: %a" msg pp e)

--- a/memory_pressure.ml
+++ b/memory_pressure.ml
@@ -6,7 +6,7 @@ open Lwt
 let src = Logs.Src.create "memory_pressure" ~doc:"Memory pressure monitor"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let total_pages = Os_xen.MM.Heap_pages.total ()
+let total_pages = OS.MM.Heap_pages.total ()
 let pagesize_kb = Io_page.page_size / 1024
 
 let meminfo ~used =
@@ -23,7 +23,7 @@ let meminfo ~used =
 
 let report_mem_usage used =
   Lwt.async (fun () ->
-    let open Os_xen in
+    let open OS in
     Xs.make () >>= fun xs ->
     Xs.immediate xs (fun h ->
       Xs.write h "memory/meminfo" (meminfo ~used)
@@ -32,16 +32,16 @@ let report_mem_usage used =
 
 let init () =
   Gc.full_major ();
-  let used = Os_xen.MM.Heap_pages.used () in
+  let used = OS.MM.Heap_pages.used () in
   report_mem_usage used
 
 let status () =
-  let used = Os_xen.MM.Heap_pages.used () |> float_of_int in
+  let used = OS.MM.Heap_pages.used () |> float_of_int in
   let frac = used /. float_of_int total_pages in
   if frac < 0.9 then `Ok
   else (
     Gc.full_major ();
-    let used = Os_xen.MM.Heap_pages.used () in
+    let used = OS.MM.Heap_pages.used () in
     report_mem_usage used;
     let frac = float_of_int used /. float_of_int total_pages in
     if frac > 0.9 then `Memory_critical

--- a/my_nat.mli
+++ b/my_nat.mli
@@ -10,7 +10,7 @@ type action = [
   | `Redirect of Mirage_nat.endpoint
 ]
 
-val create : get_time:(unit -> Mirage_nat.time) -> max_entries:int -> t Lwt.t
+val create : max_entries:int -> t Lwt.t
 val reset : t -> unit Lwt.t
 val translate : t -> Nat_packet.t -> Nat_packet.t option Lwt.t
 val add_nat_rule_and_translate : t -> xl_host:Ipaddr.V4.t ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -46,7 +46,7 @@ module Main (Clock : Mirage_clock_lwt.MCLOCK) = struct
         (fun `Cant_happen -> assert false)
         (fun ex ->
           Log.warn (fun f -> f "GUI thread failed: %s" (Printexc.to_string ex));
-          return ()
+          Lwt.return_unit
         )
     )
 
@@ -70,7 +70,7 @@ module Main (Clock : Mirage_clock_lwt.MCLOCK) = struct
     (* Watch for shutdown requests from Qubes *)
     let shutdown_rq =
       OS.Lifecycle.await_shutdown_request () >>= fun (`Poweroff | `Reboot) ->
-      return () in
+      Lwt.return_unit in
     (* Set up networking *)
     let max_entries = Key_gen.nat_table_size () in
     My_nat.create ~max_entries >>= fun nat ->

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -7,7 +7,7 @@ open Qubes
 let src = Logs.Src.create "unikernel" ~doc:"Main unikernel code"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Main (Clock : Mirage_clock_lwt.MCLOCK) = struct
+module Main (Clock : Mirage_clock.MCLOCK) = struct
   module Uplink = Uplink.Make(Clock)
 
   (* Set up networking and listen for incoming packets. *)

--- a/uplink.ml
+++ b/uplink.ml
@@ -9,7 +9,7 @@ module Eth = Ethernet.Make(Netif)
 let src = Logs.Src.create "uplink" ~doc:"Network connection to NetVM"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
+module Make(Clock : Mirage_clock.MCLOCK) = struct
   module Arp = Arp.Make(Eth)(OS.Time)
 
   type t = {

--- a/uplink.ml
+++ b/uplink.ml
@@ -17,6 +17,7 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
     eth : Eth.t;
     arp : Arp.t;
     interface : interface;
+    fragments : Fragments.Cache.t;
   }
 
   class netvm_iface eth mac ~my_ip ~other_ip : interface = object
@@ -31,13 +32,13 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
       )
   end
 
-  let listen t router =
+  let listen t get_ts router =
     Netif.listen t.net ~header_size:Ethernet_wire.sizeof_ethernet (fun frame ->
         (* Handle one Ethernet frame from NetVM *)
         Eth.input t.eth
           ~arpv4:(Arp.input t.arp)
           ~ipv4:(fun ip ->
-              match Nat_packet.of_ipv4_packet ip with
+              match Nat_packet.of_ipv4_packet t.fragments ~now:(get_ts ()) ip with
               | exception ex ->
                 Log.err (fun f -> f "Error unmarshalling ethernet frame from uplink: %s@.%a" (Printexc.to_string ex)
                             Cstruct.hexdump_pp frame
@@ -46,7 +47,8 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
               | Error e ->
                 Log.warn (fun f -> f "Ignored unknown IPv4 message from uplink: %a" Nat_packet.pp_error e);
                 Lwt.return ()
-              | Ok packet ->
+              | Ok None -> Lwt.return_unit
+              | Ok (Some packet) ->
                 Firewall.ipv4_from_netvm router packet
             )
           ~ipv6:(fun _ip -> return ())
@@ -55,7 +57,7 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
 
   let interface t = t.interface
 
-  let connect ~clock:_ config =
+  let connect config =
     let ip = config.Dao.uplink_our_ip in
     Netif.connect "0" >>= fun net ->
     Eth.connect net >>= fun eth ->
@@ -67,5 +69,6 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
     let interface = new netvm_iface eth netvm_mac
       ~my_ip:ip
       ~other_ip:config.Dao.uplink_netvm_ip in
-    return { net; eth; arp; interface }
+    let fragments = Fragments.Cache.create (256 * 1024) in
+    return { net; eth; arp; interface ; fragments }
 end

--- a/uplink.ml
+++ b/uplink.ml
@@ -46,12 +46,12 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
                 Lwt.return_unit
               | Error e ->
                 Log.warn (fun f -> f "Ignored unknown IPv4 message from uplink: %a" Nat_packet.pp_error e);
-                Lwt.return ()
+                Lwt.return_unit
               | Ok None -> Lwt.return_unit
               | Ok (Some packet) ->
                 Firewall.ipv4_from_netvm router packet
             )
-          ~ipv6:(fun _ip -> return ())
+          ~ipv6:(fun _ip -> Lwt.return_unit)
           frame
       ) >|= or_raise "Uplink listen loop" Netif.pp_error
 
@@ -70,5 +70,5 @@ module Make(Clock : Mirage_clock_lwt.MCLOCK) = struct
       ~my_ip:ip
       ~other_ip:config.Dao.uplink_netvm_ip in
     let fragments = Fragments.Cache.create (256 * 1024) in
-    return { net; eth; arp; interface ; fragments }
+    Lwt.return { net; eth; arp; interface ; fragments }
 end

--- a/uplink.mli
+++ b/uplink.mli
@@ -8,12 +8,12 @@ open Fw_utils
 module Make(Clock : Mirage_clock_lwt.MCLOCK) : sig
   type t
 
-  val connect : clock:Clock.t -> Dao.network_config -> t Lwt.t
+  val connect : Dao.network_config -> t Lwt.t
   (** Connect to our NetVM (gateway). *)
 
   val interface : t -> interface
   (** The network interface to NetVM. *)
 
-  val listen : t -> Router.t -> unit Lwt.t
+  val listen : t -> (unit -> int64) -> Router.t -> unit Lwt.t
   (** Handle incoming frames from NetVM. *)
 end

--- a/uplink.mli
+++ b/uplink.mli
@@ -5,7 +5,7 @@
 
 open Fw_utils
 
-module Make(Clock : Mirage_clock_lwt.MCLOCK) : sig
+module Make(Clock : Mirage_clock.MCLOCK) : sig
   type t
 
   val connect : Dao.network_config -> t Lwt.t


### PR DESCRIPTION
The main improvement is fragmentation and reassembly support in mirage-nat 2.0.0, which fixes #73 //cc @xaki23.

Other changes include:
- update to mirage-xen 5.0.0 (which reverted the split OS -> OS & Os_xen, back to OS),
- upgrade to mirage-qubes 0.8.0 (where GUI.listen signature changed),
- fix deprecation warnings (Mirage_clock_lwt is deprecated, using Mirage_clock instead),
- remove Fw_utils.return and fail, use Lwt.return_unit across the codebase (instead of Lwt.return () or return ()).

Fragmentation and reassembly: each network interface now has a reassembly cache, a LRU, its size is hardcoded to 256 * 1024 bytes. I am not sure whether this should instead (a) be user-configurable (b) default to a smaller size. Maybe the individual client networks (Client_net) should have a smaller cache, and the Uplink a slightly larger?