### PR TITLE
support mirage-3.7 via qubes-builder

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -3,5 +3,6 @@ OCAML_VERSION ?= 4.08.1
 SOURCE_BUILD_DEP := firewall-build-dep
 
 firewall-build-dep:
-	opam pin -y add mirage 3.5.2
+	opam install -y depext
+	opam depext -i -y mirage.3.7.4 lwt.4.5.0
 


### PR DESCRIPTION
basicly just replicates two minors to the qubes-builder path:
 - the move to mirage-3.7 
 - and early lwt-4.5 to avoid version-yoyo
 - and replaces pin by depext (which makes the depext part cut-n-paste from the Dockerfile)

change is tested+working.
