### PR TITLE
Add code build with docker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### master branch
+### 0.7
 
 This version adapts qubes-mirage-firewall with
 - dynamic rulesets via QubesDB (as defined in Qubes 4.0), and
@@ -11,7 +11,6 @@ A test unikernel is available in the test subdirectory.
 This project was done by @linse and @yomimono in summer 2019, see PR #96.
 
 Additional changes and bugfixes:
-TODO: describe based on commit log de7d05e .. 02e515d
 
 - Support Mirage 3.7 and mirage-nat 2.0.0 (@hannesm, #89).
   The main improvement is fragmentation and reassembly support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # Pin the base image to a specific hash for maximum reproducibility.
 # It will probably still work on newer images, though, unless Debian
 # changes some compiler optimisations (unlikely).
-#FROM ocurrent/opam:alpine-3.10-ocaml-4.08
-FROM ocurrent/opam@sha256:3f3ce7e577a94942c7f9c63cbdd1ecbfe0ea793f581f69047f3155967bba36f6
+#FROM ocurrent/opam:alpine-3.10-ocaml-4.10
+FROM ocurrent/opam@sha256:d30098ff92b5ee10cf7c11c17f2351705e5226a6b05aa8b9b7280b3d87af9cde
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 3548c2a8537029b8165466cd9c5a94bb7bc30405 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 4dd2620bcc821418bae53669a6c6163964c090a2 && opam update
 
-RUN opam depext -i -y mirage.3.7.6 lwt.5.2.0
+RUN opam depext -i -y mirage.3.7.7 lwt.5.3.0
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,7 @@ RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall
 RUN opam config exec -- mirage configure -t xen && make depend
+ADD . /home/opam/qubes-mirage-firewall
+RUN sudo chown -R opam /home/opam/qubes-mirage-firewall
 CMD opam config exec -- mirage configure -t xen && \
     opam config exec -- make tar

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -4,5 +4,5 @@ SOURCE_BUILD_DEP := firewall-build-dep
 
 firewall-build-dep:
 	opam install -y depext
-	opam depext -i -y mirage.3.7.6 lwt.5.2.0
+	opam depext -i -y mirage.3.7.7 lwt.5.3.0
 

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: 7a6b003e712256cce7ac8741239f6d8d5a0db4b71656396f7ee734568282c72d"
+echo "SHA2 last known: 4f4456b5fe7c8ae1ba2f6934cf89749cf6aae9a90cce899cf744c89d311467a3"
 echo "(hashes should match for released versions)"


### PR DESCRIPTION
Hi @talex5 , we needed to add these lines in order to run `build_with_docker.sh` successfully on a Debian qube with Docker version `19.03.9`. Do you think this change is sensible or is it intended to be called in a different way? We took these lines from `.travis.yml`