### PR TITLE
adapt to mirage 3.8.0 changes (ipaddr5, tcpip5); bump opam-repository hash (to get netchannel+mirage-net-xen 0.13.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ FROM ocurrent/opam@sha256:d30098ff92b5ee10cf7c11c17f2351705e5226a6b05aa8b9b7280b
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 0cd6dafebfb49a3b56cce8e6651aa83c591214d5 && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard e81ab2996896b21cba74c43a903b305a5a6341ef && opam update
 
-RUN opam depext -i -y mirage.3.7.7 lwt.5.3.0
+RUN opam depext -i -y mirage.3.8.0 lwt.5.3.0
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -4,5 +4,5 @@ SOURCE_BUILD_DEP := firewall-build-dep
 
 firewall-build-dep:
 	opam install -y depext
-	opam depext -i -y mirage.3.7.7 lwt.5.3.0
+	opam depext -i -y mirage.3.8.0 lwt.5.3.0
 

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: c2d7206d57e5977a608735af46e5ac5af0aa6cd5e052f0a177322dd76b67690c"
+echo "SHA2 last known: 0f6b41fa3995afccff1809cb893c45c0863477d4dfacc441c11e3382bec31d39"
 echo "(hashes should match for released versions)"

--- a/uplink.ml
+++ b/uplink.ml
@@ -83,8 +83,8 @@ let connect config =
   Eth.connect net >>= fun eth ->
   Arp.connect eth >>= fun arp ->
   Arp.add_ip arp my_ip >>= fun () ->
-  let network = Ipaddr.V4.Prefix.make 0 Ipaddr.V4.any in
-  I.connect ~ip:(network, my_ip) ~gateway eth arp >>= fun ip ->
+  let cidr = Ipaddr.V4.Prefix.make 0 my_ip in
+  I.connect ~cidr ~gateway eth arp >>= fun ip ->
   U.connect ip >>= fun udp ->
   let netvm_mac =
     Arp.query arp gateway


### PR DESCRIPTION
note: the sha256 hash of the image should be adapted. this will fix #111 (so a 0.7.2 release would be welcome (I don't have infrastructure to run the release process atm, in case someone else can do this, that'd be appreciated))