### PR TITLE
Upgrade to Mirage 6 for solo5 PVH support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Pin the base image to a specific hash for maximum reproducibility.
-# It will probably still work on newer images, though, unless Debian
+# It will probably still work on newer images, though, unless an update
 # changes some compiler optimisations (unlikely).
-#FROM ocurrent/opam:alpine-3.10-ocaml-4.10
-FROM ocurrent/opam@sha256:4546b41a99b54f163af435327c86f88d06346f2a059f0f42bea431b37329ea8d
+#FROM ocurrent/opam:fedora-32-ocaml-4.10
+FROM ocurrent/opam@sha256:2e0e1689d2260c202bf944034f15ba8ebe945dba6b126cc6dd6b185c223014f3
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # It will probably still work on newer images, though, unless Debian
 # changes some compiler optimisations (unlikely).
 #FROM ocurrent/opam:alpine-3.10-ocaml-4.10
-FROM ocurrent/opam@sha256:d30098ff92b5ee10cf7c11c17f2351705e5226a6b05aa8b9b7280b3d87af9cde
+FROM ocurrent/opam@sha256:4546b41a99b54f163af435327c86f88d06346f2a059f0f42bea431b37329ea8d
 
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard e81ab2996896b21cba74c43a903b305a5a6341ef && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard 6ef290f5681b7ece5d9c085bcf0c55268c118292 && opam update
 
-RUN opam depext -i -y mirage.3.8.0 lwt.5.3.0
+RUN opam depext -i -y mirage
 RUN mkdir /home/opam/qubes-mirage-firewall
 ADD config.ml /home/opam/qubes-mirage-firewall/config.ml
 WORKDIR /home/opam/qubes-mirage-firewall

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: 0f6b41fa3995afccff1809cb893c45c0863477d4dfacc441c11e3382bec31d39"
+echo "SHA2 last known: a635ead410ffb72abb8b44e8c5f8f2cfc8752c4787e737ed6cdc0089143ace00"
 echo "(hashes should match for released versions)"

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum qubes_firewall.xen)"
-echo "SHA2 last known: a635ead410ffb72abb8b44e8c5f8f2cfc8752c4787e737ed6cdc0089143ace00"
+echo "SHA2 last known: 583d22327500fa092f436af1d0d9b1b78ebe12abd814c128ec7452c2f4cf319a"
 echo "(hashes should match for released versions)"

--- a/config.ml
+++ b/config.ml
@@ -33,7 +33,7 @@ let main =
       package "mirage-qubes" ~min:"0.8.2";
       package "mirage-nat" ~min:"2.2.1";
       package "mirage-logs";
-      package "mirage-xen" ~min:"5.0.0";
+      package "mirage-xen" ~min:"6.0.0";
       package ~min:"4.5.0" "dns-client";
       package "pf-qubes";
     ]


### PR DESCRIPTION
This PR updates the Dockerfile to collect together the various pins needed to test solo5 PVH support from e.g. https://github.com/mirage/mirage/issues/1184.

Once this works, it will fix #29.

For me, it boots but then doesn't respond further (e.g. to `qvm-run` commands). Attempting to start a client just times out (probably because it doesn't connect the new network device).

```
$ test-mirage qubes_firewall.xen mirage-firewall-staging
Waiting for 'Ready'... OK
Uploading 'qubes_firewall.xen' (7340600 bytes) to "mirage-firewall-staging"
Waiting for 'Booting'... OK
Connecting to mirage-firewall-staging console...
Solo5: Xen console: port 0x2, ring @0x00000000FEFFF000
Solo5: using E820 memory map
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
Solo5: Bindings version v0.6.6-2-g20196872
Solo5: Memory map: 32 MB addressable:
Solo5:   reserved @ (0x0 - 0xfffff)
Solo5:       text @ (0x100000 - 0x2edfff)
Solo5:     rodata @ (0x2ee000 - 0x350fff)
Solo5:       data @ (0x351000 - 0x4b7fff)
Solo5:       heap >= 0x4b8000 < stack < 0x2000000
2020-08-19 13:42:26 -00:00: INF [qubes.rexec] waiting for client...
2020-08-19 13:42:26 -00:00: INF [qubes.gui] waiting for client...
2020-08-19 13:42:26 -00:00: INF [qubes.db] connecting to server...
2020-08-19 13:42:26 -00:00: INF [qubes.db] connected
2020-08-19 13:42:26 -00:00: INF [qubes.rexec] client connected, using protocol version 2
```

In dom0, I ran `gdbsx -a $DOMID 64 9999` and then:
```
[tal@dom0 ~]$ gdb /var/lib/qubes/vm-kernels/mirage-firewall-staging/vmlinuz 
(gdb) target remote :9999
Remote debugging using :9999
warning: remote target does not support file transfer, attempting to access files from local filesystem.
warning: Unable to find dynamic linker breakpoint function.
GDB will be unable to debug shared library initializers
and track explicitly loaded dynamic code.
mirage_xen_evtchn_block_domain (v_deadline=<optimized out>) at bindings/evtchn.c:343
343	bindings/evtchn.c: No such file or directory.
(gdb) bt
#0  mirage_xen_evtchn_block_domain (v_deadline=<optimized out>) at bindings/evtchn.c:343
#1  0x00000000001a2191 in camlOS__Main__aux_141 () at lib/main.ml:56
#2  0x000000000010bb05 in camlMain__entry () at main.ml:5
#3  0x0000000000107e69 in caml_program ()
#4  0x0000000000282df4 in caml_start_program ()
#5  0x000000000026596c in caml_startup_common (argv=argv@entry=0x499c90 <unused_argv>, pooling=<optimized out>, 
    pooling@entry=0) at startup_nat.c:162
#6  0x00000000002659ab in caml_startup_exn (argv=argv@entry=0x499c90 <unused_argv>) at startup_nat.c:172
#7  caml_startup (argv=argv@entry=0x499c90 <unused_argv>) at startup_nat.c:172
#8  0x000000000026564c in solo5_app_main (si=si@entry=0x49b010 <si>) at bindings/main.c:114
#9  0x00000000001011a4 in _start2 (arg=<optimized out>) at xen/start.c:80
#10 0x00000000001010a2 in _newstack () at xen/boot.S:154
#11 0x0000000000000000 in ?? ()
```

/cc @mato