### PR TITLE
README: use kernelopts='' instead of None

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run this command in dom0 to create a `mirage-firewall` VM using the `mirage-fire
 ```
 qvm-create \
   --property kernel=mirage-firewall \
-  --property kernelopts=None \
+  --property kernelopts='' \
   --property memory=64 \
   --property maxmem=64 \
   --property netvm=sys-net \


### PR DESCRIPTION
this is especially important with the upcoming mirage 3.9 release (which no longer filters boot parameters).