### PR TITLE
update to dns 6.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN cd /home/opam/opam-repository && git fetch origin master && git reset --hard 0f451c34c56458ee18495a98eb35d7dcb14f519a && opam update
+RUN cd /home/opam/opam-repository && git fetch origin master && git reset --hard 7b89f6e5c24cf4076252e71abcbbe4d205705627 && opam update
 
 RUN opam install -y mirage opam-monorepo
 RUN mkdir /home/opam/qubes-mirage-firewall

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 73488b0c54d6c43d662ddf58916b6d472430894f6394c6bdb8a879723abcc06f"
+echo "SHA2 last known: 88fdd86993dfbd2e2c4a4d502c350bef091d7831405cf983aebe85f936799f2d"
 echo "(hashes should match for released versions)"

--- a/config.ml
+++ b/config.ml
@@ -31,7 +31,7 @@ let main =
       package "mirage-nat" ~min:"3.0.0";
       package "mirage-logs";
       package "mirage-xen" ~min:"8.0.0";
-      package ~min:"6.1.0" "dns-client";
+      package ~min:"6.4.0" "dns-client";
       package "pf-qubes";
     ]
     "Unikernel.Main" (random @-> mclock @-> time @-> job)

--- a/my_dns.ml
+++ b/my_dns.ml
@@ -28,7 +28,7 @@ module Transport (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Time : Mirage_
     let timeout = Time.sleep_ns timeout_ns >|= fun () -> Error (`Msg "DNS request timeout") in
     Lwt.pick [ f ; timeout ]
 
-  let connect (t : t) = Lwt.return (Ok t)
+  let connect (t : t) = Lwt.return (Ok (t.protocol, t))
 
   let send_recv (ctx : context) buf : (Cstruct.t, [> `Msg of string ]) result Lwt.t =
     let open Router in


### PR DESCRIPTION
There's an API change in dns-client (the function `connect` returns a tuple of protocols and flow), which we follow with this commit.