### PR TITLE
Reproducible build systems: use in GitHub action the build-with-docker.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ocaml-compiler:
-          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 
@@ -23,19 +21,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+      - run: ./build-with-docker.sh
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
-      - run: opam depext solo5 "mirage>4"
-
-      - run: opam install solo5 "mirage>4"
-
-      - run: opam exec -- mirage configure -t xen
-
-      - run: opam exec -- make depend
-
-      - run: opam exec -- dune build
-
-      - run: sha256sum dist/qubes-firewall.xen
+          name: mirage-firewall.tar.bz2
+          path: mirage-firewall.tar.bz2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
 
       - run: ./build-with-docker.sh
 
+      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen | cut -d " " -f 1) = $(grep "SHA2 last known" build-with-docker.sh | rev | cut -d ":" -f 1 | rev | cut -d "\"" -f 1 | tr -d " ") ]; then echo "SHA256 MATCHES"; else exit 42; fi'
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile.user
+++ b/Makefile.user
@@ -1,6 +1,8 @@
 tar: build
 	rm -rf _build/mirage-firewall
 	mkdir _build/mirage-firewall
+	cp dist/qubes-firewall.xen dist/qubes-firewall.xen.debug
+	strip dist/qubes-firewall.xen
 	cp dist/qubes-firewall.xen _build/mirage-firewall/vmlinuz
 	touch _build/mirage-firewall/modules.img
 	cat /dev/null | gzip -n > _build/mirage-firewall/initramfs

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -3,7 +3,7 @@ set -eu
 echo Building Docker image with dependencies..
 docker build -t qubes-mirage-firewall .
 echo Building Firewall...
-docker run --rm -i -v `pwd`:/home/opam/qubes-mirage-firewall qubes-mirage-firewall
+docker run --rm -i -v `pwd`:/tmp/orb-build qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: f499b2379c62917ac32854be63f201e6b90466e645e54dea51e376baccdf26ab"
+echo "SHA2 last known: 3f71a1b672a15d145c7d40405dd75f06a2b148d2cfa106dc136e3da38552de41"
 echo "(hashes should match for released versions)"


### PR DESCRIPTION
Also upload the artifact to GitHub action, and in addition use the same setup (ubuntu 20.04 image) and build directories as done on builds.robur.coop.

Also use `strip` on the resulting binary to reduce it's size (since the debug section aren't mapped into the running unikernel, there's nothing we get from them -- also they are preserved (as .debug file) and uploaded to https://builds.robur.coop if one needs them).

This entails binary reproducibility between the different systems:
- a developer using ./build-with-docker.sh
- GitHub action (run on every PR)
- builds.robur.coop with the ubuntu-20.04 worker

The situation before:
- build-with-docker.sh used a Docker image from "ocaml/opam" which was based on fedora-35 and included OCaml 4.14.
- GitHub action used the ubuntu-latest (a 22.04 image, at the current state of writing https://github.com/actions/runner-images)
- builds.robur.coop used a ubuntu 20.04 image https://builds.robur.coop/job/qubes-firewall?platform=ubuntu-20.04

I tried to get them reproducible, but even using a "ubuntu 22.04" image from ocaml/opam and GitHub action did not lead to the same output (it is the same C compiler, but they report versions differently for some reason).

So instead I stick to the official ubuntu 20.04 image (we can of course upgrade at any time -- but we should then as well have a worker on builds.robur.coop doing this build), which is very small in size.

The drawback is that compilation (execution of ./build-with-docker.sh) on a high-speed Internet connection will take some more time (since the OCaml compiler is bootstrapped). Another drawback is that in the Dockerfile the `opam` binary is manually downloaded from github.com -- reason is that we need a recent one (>= 2.1.0 for MirageOS 4; and ubuntu 20.04 only ships 2.0.5 -- solved in ubuntu 22.04 which ships 2.1.2).

The advantage is that we've build information (reproducible-builds.org terminology) / SBOM (software bill of materials) data independent of Docker:
- the system packages https://builds.robur.coop/job/qubes-firewall/build/04fa553a-a4dd-4433-b853-f91e6fa0d12e/f/system-packages
- the opam packages (with checksums or git commits) https://builds.robur.coop/job/qubes-firewall/build/04fa553a-a4dd-4433-b853-f91e6fa0d12e/f/opam-switch

And any user of qubes-mirage-firewall can lookup their binary sha256 (sha256 /path/to/vmlinuz ; with this PR merged it is 3f71a1b672a15d145c7d40405dd75f06a2b148d2cfa106dc136e3da38552de41) at https://builds.robur.coop/hash?sha256=3f71a1b672a15d145c7d40405dd75f06a2b148d2cfa106dc136e3da38552de41 (there's an input field on https://builds.robur.coop) and find out
- the build information (sources [system packages, opam packages]) sufficient to reproduce the exact same binary (eventually even on other Linux distributions when using the same C compiler, etc.)
- whether there are newer builds with different output (and what changed in terms of input, e.g. a new release of a dependency)

All this is in my opinion a much neater story for the binaries we provide. NB that builds.robur.coop uses (a) orb (from https://github.com/roburio/orb) for building the package and (b) on a daily basis the HEAD of opam-repository (while `Dockerfile` has a specific commit hardcoded). This means that the latest build on builds.robur.coop may be different from the local build or GitHub action build.

//cc @palainp 