### PR TITLE
remove memreport to Xen to avoid Qubes trying to get back some memory…

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/tmp/orb-build qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 55a2f823d66473c7d0be66a93289d48b6557f18c9257c6f98aa5a4583663d3c2"
+echo "SHA2 last known: d9f7827e2f2c8150ac97a4d348a29f5ee0810a455dbab9233490fff97470f7b8"
 echo "(hashes should match for released versions)"


### PR DESCRIPTION
… from us

Some qubes-mirage-firewall users have reported AppVMs being stuck at their lowmem value (https://forum.qubes-os.org/t/new-usability-issues-dom0-processes-making-system-unusable/18301/2 and https://forum.qubes-os.org/t/memory-allocation-problem-remains-in-low-allocation-for-minutes/18787). This causes the AppVMs to use swap and be very slow.

After some investigations (the issue appears when the system is under heavy memory pressure, a new AppVM is started and Qubes have to find memory). It seems that, when the `meminfo` key is set, the unikernel is considered by Qubes as taking part in the memory balancing process. Some VM have a `meminfo` entry, some haven't:
```
$ xenstore ls /local/domain/1/memory
static-max = "614400"
target = "598016"
videoram = "16384"
$ xenstore ls /local/domain/8/memory
static-max = "4096000"
target = "4079616"
videoram = "0"
meminfo = "966160"
```

I've tried, without any luck, to write in `meminfo` our total_mem (we always want to have our memory, we're currently unable to downsize our memory) but it differs from the actual total memory (meminfo="27384" vs static-max="32768", still no idea why). I then tried never writing to `meminfo` (this commit) which solve the issue (at least on my laptop and rrn in the qubes-forum, https://forum.qubes-os.org/t/memory-allocation-problem-remains-in-low-allocation-for-minutes/18787/20) and doesn't seem to have any drawback.
