### PR TITLE
Using too little RAM causes Mirage to stop working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Run this command in dom0 to create a `mirage-firewall` VM using the `mirage-fire
 qvm-create \
   --property kernel=mirage-firewall \
   --property kernelopts='' \
-  --property memory=32 \
-  --property maxmem=32 \
+  --property memory=64 \
+  --property maxmem=64 \
   --property netvm=sys-net \
   --property provides_network=True \
   --property vcpus=1 \

--- a/SaltScriptToDownloadAndInstallMirageFirewallInQubes.sls
+++ b/SaltScriptToDownloadAndInstallMirageFirewallInQubes.sls
@@ -73,8 +73,8 @@ create-sys-mirage-fw:
       - kernel: mirage-firewall
       - kernelopts:
       - include-in-backups: False
-      - memory: 32
-      - maxmem: 32
+      - memory: 64
+      - maxmem: 64
       - netvm: sys-net
       - provides-network: True
       - vcpus: 1


### PR DESCRIPTION
I have several VMs that use Mirage Firewall, and when it reaches up to three VMs, all VMs lose network connectivity. A Mirage restart is required. After increasing the RAM, I no longer experience any issues.