### PR TITLE
Fix docker build & update build scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,7 @@ RUN opam exec -- opam install -y mirage opam-monorepo ocaml-solo5
 RUN mkdir /tmp/orb-build
 ADD config.ml /tmp/orb-build/config.ml
 WORKDIR /tmp/orb-build
-CMD opam exec -- sh -exc 'mirage configure -t xen --allocation-policy=best-fit && make depend && make tar'
+CMD opam exec -- sh -exc 'mirage configure -t xen --extra-repos=\
+opam-overlays:https://github.com/dune-universe/opam-overlays.git#91a371754a2c9f4febbb6c7bb039649ad49a3c13,\
+mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#05f1c1823d891ce4d8adab91f5db3ac51d86dc0b \
+--allocation-policy=best-fit && make depend && make tar'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # Pin the base image to a specific hash for maximum reproducibility.
 # It will probably still work on newer images, though, unless an update
 # changes some compiler optimisations (unlikely).
-# bookworm-slim
-FROM debian@sha256:07c6cb2ae86479dcc1942a89b0a1f4049b6e9415f7de327ff641aed58b8e3100
+# bookworm-slim taken from https://hub.docker.com/_/debian/tags?page=1&name=bookworm-slim
+FROM debian@sha256:ea5ad531efe1ac11ff69395d032909baf423b8b88e9aade07e11b40b2e5a1338
+# install ca-certificates and remove default packages repository
+RUN rm /etc/apt/sources.list.d/debian.sources
 # and set the package source to a specific release too
-RUN printf "deb [check-valid-until=no] http://snapshot.notset.fr/archive/debian/20230418T024659Z bookworm main" > /etc/apt/sources.list
+# taken from https://snapshot.debian.org/archive/debian
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20231107T084929Z bookworm main\n" > /etc/apt/sources.list
+# taken from https://snapshot.debian.org/archive/debian-security/
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20231108T004541Z bookworm-security main\n" >> /etc/apt/sources.list
 
 RUN apt update && apt install --no-install-recommends --no-install-suggests -y wget ca-certificates git patch unzip bzip2 make gcc g++ libc-dev
 RUN wget -O /usr/bin/opam https://github.com/ocaml/opam/releases/download/2.1.5/opam-2.1.5-i686-linux && chmod 755 /usr/bin/opam
@@ -14,7 +19,8 @@ ENV OPAMCONFIRMLEVEL=unsafe-yes
 # Pin last known-good version for reproducible builds.
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
-RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#28b35f67988702df5018fbf30d1c725734425670
+# taken from https://github.com/ocaml/opam-repository
+RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#d1a8bf040fbb2c81ddb2612f1a49a471a06083dc
 RUN opam switch create myswitch 4.14.1
 RUN opam exec -- opam install -y mirage opam-monorepo ocaml-solo5
 RUN mkdir /tmp/orb-build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Note: The most reliable way to build is using Docker.
 Fedora 38 works well for this, Debian 12 also works, but you'll need to follow the instructions at [docker.com][debian-docker] to get Docker
 (don't use Debian's version).
 
-Create a new Fedora-38 AppVM (or reuse an existing one). In the Qube's Settings (Basic / Disk storage), increase the private storage max size from the default 2048 MiB to 4096 MiB. Open a terminal.
+Create a new Fedora-38 AppVM (or reuse an existing one). In the Qube's Settings (Basic / Disk storage), increase the private storage max size from the default 2048 MiB to 8192 MiB. Open a terminal.
 
 Clone this Git repository and run the `build-with-docker.sh` script (Note: The `chcon` call is mandatory on Fedora with new SELinux policies which do not allow to standardly keep the docker images in homedir):
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ See the [Deploy](#deploy) section below for installation instructions.
 ## Build from source
 
 Note: The most reliable way to build is using Docker.
-Fedora 38 works well for this, Debian 11 also works (and Debian 12 should), but you'll need to follow the instructions at [docker.com][debian-docker] to get Docker
+Fedora 38 works well for this, Debian 12 also works, but you'll need to follow the instructions at [docker.com][debian-docker] to get Docker
 (don't use Debian's version).
 
 Create a new Fedora-38 AppVM (or reuse an existing one). In the Qube's Settings (Basic / Disk storage), increase the private storage max size from the default 2048 MiB to 4096 MiB. Open a terminal.
 
-Clone this Git repository and run the `build-with-docker.sh` script (Note: The `chcon` call is mandatory with new SELinux policies which do not allow to standardly keep the images in homedir):
+Clone this Git repository and run the `build-with-docker.sh` script (Note: The `chcon` call is mandatory on Fedora with new SELinux policies which do not allow to standardly keep the docker images in homedir):
 
     mkdir /home/user/docker
     sudo ln -s /home/user/docker /var/lib/docker
@@ -30,7 +30,7 @@ Clone this Git repository and run the `build-with-docker.sh` script (Note: The `
     cd qubes-mirage-firewall
     sudo ./build-with-docker.sh
 
-This took about 10 minutes on my laptop (it will be much quicker if you run it again).
+This took about 15 minutes on my laptop (it will be much quicker if you run it again).
 The symlink step at the start isn't needed if your build VM is standalone.
 It gives Docker more disk space and avoids losing the Docker image cache when you reboot the Qube.
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ See the [Deploy](#deploy) section below for installation instructions.
 ## Build from source
 
 Note: The most reliable way to build is using Docker.
-Fedora 35 works well for this and Debian 11 also works, but you'll need to follow the instructions at [docker.com][debian-docker] to get Docker
+Fedora 38 works well for this, Debian 11 also works (and Debian 12 should), but you'll need to follow the instructions at [docker.com][debian-docker] to get Docker
 (don't use Debian's version).
 
-Create a new Fedora-35 AppVM (or reuse an existing one). In the Qube's Settings (Basic / Disk storage), increase the private storage max size from the default 2048 MiB to 4096 MiB. Open a terminal.
+Create a new Fedora-38 AppVM (or reuse an existing one). In the Qube's Settings (Basic / Disk storage), increase the private storage max size from the default 2048 MiB to 4096 MiB. Open a terminal.
 
-Clone this Git repository and run the `build-with-docker.sh` script:
+Clone this Git repository and run the `build-with-docker.sh` script (Note: The `chcon` call is mandatory with new SELinux policies which do not allow to standardly keep the images in homedir):
 
     mkdir /home/user/docker
     sudo ln -s /home/user/docker /var/lib/docker
+    sudo chcon -Rt container_file_t /home/user/docker
     sudo dnf install docker
     sudo systemctl start docker
     git clone https://github.com/mirage/qubes-mirage-firewall.git
@@ -141,7 +142,7 @@ The boot process:
 For development, use the [test-mirage][] scripts to deploy the unikernel (`qubes-firewall.xen`) from your development AppVM.
 This takes a little more setting up the first time, but will be much quicker after that. e.g.
 
-    $ test-mirage dist/qubes-firewall.xen mirage-firewall
+    [user@dev ~]$ test-mirage dist/qubes-firewall.xen mirage-firewall
     Waiting for 'Ready'... OK
     Uploading 'dist/qubes-firewall.xen' (7454880 bytes) to "mirage-test"
     Waiting for 'Booting'... OK

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -3,7 +3,7 @@ set -eu
 echo Building Docker image with dependencies..
 docker build -t qubes-mirage-firewall .
 echo Building Firewall...
-docker run --rm -i -v `pwd`:/tmp/orb-build qubes-mirage-firewall
+docker run --rm -i -v `pwd`:/tmp/orb-build:Z qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
 echo "SHA2 last known: 8ae5314edf5b863b788c4b873e27bc4b206a2ff7ef1051c4c62ae41584ed3e14"
 echo "(hashes should match for released versions)"

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -5,5 +5,5 @@ docker build -t qubes-mirage-firewall .
 echo Building Firewall...
 docker run --rm -i -v `pwd`:/tmp/orb-build:Z qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 8ae5314edf5b863b788c4b873e27bc4b206a2ff7ef1051c4c62ae41584ed3e14"
+echo "SHA2 last known: 2c3f68f49afdeaeedd2c03f8ef6d30d6bb4d6306bda0a1ff40f95f440a90034c"
 echo "(hashes should match for released versions)"


### PR DESCRIPTION
This PR wants to address #183 and #184:
- With Qubes 4.2 SELinux policies are enforced and now we need to run an additional command to be allowed to store docker images in the user homedir
- A recent update in opam-overlay changed the result hashsum, therefore I updated the build scripts (change from notset.fr to official debian repositories, update to mirage 4.4.0, ...)