### PR TITLE
set back recommended memory amount to 32MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Run this command in dom0 to create a `mirage-firewall` VM using the `mirage-fire
 qvm-create \
   --property kernel=mirage-firewall \
   --property kernelopts='' \
-  --property memory=64 \
-  --property maxmem=64 \
+  --property memory=32 \
+  --property maxmem=32 \
   --property netvm=sys-net \
   --property provides_network=True \
   --property vcpus=1 \

--- a/SaltScriptToDownloadAndInstallMirageFirewallInQubes.sls
+++ b/SaltScriptToDownloadAndInstallMirageFirewallInQubes.sls
@@ -73,8 +73,8 @@ create-sys-mirage-fw:
       - kernel: mirage-firewall
       - kernelopts:
       - include-in-backups: False
-      - memory: 64
-      - maxmem: 64
+      - memory: 32
+      - maxmem: 32
       - netvm: sys-net
       - provides-network: True
       - vcpus: 1


### PR DESCRIPTION
Now Qubes 4.2 is out and I've been using it since Qubes 4.2-rc3 without any issue, I propose to set back the recommended quantity of memory needed for qubes-mirage-firewall to 32MB (I'm currently unable to reproduce the behavior in #181 nor #182 even when putting pressure on memory or leaving the laptop alone for a while).