### PR TITLE
Update to Mirage 4.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # It will probably still work on newer images, though, unless an update
 # changes some compiler optimisations (unlikely).
 # bookworm-slim taken from https://hub.docker.com/_/debian/tags?page=1&name=bookworm-slim
-FROM debian@sha256:ea5ad531efe1ac11ff69395d032909baf423b8b88e9aade07e11b40b2e5a1338
+FROM debian@sha256:3d5df92588469a4c503adbead0e4129ef3f88e223954011c2169073897547cac
 # install remove default packages repository
 RUN rm /etc/apt/sources.list.d/debian.sources
 # and set the package source to a specific release too
 # taken from https://snapshot.debian.org/archive/debian
-RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20231107T084929Z bookworm main\n" > /etc/apt/sources.list
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20240419T024211Z bookworm main\n" > /etc/apt/sources.list
 # taken from https://snapshot.debian.org/archive/debian-security/
-RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20231108T004541Z bookworm-security main\n" >> /etc/apt/sources.list
+RUN printf "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20240419T111010Z bookworm-security main\n" >> /etc/apt/sources.list
 
 RUN apt update && apt install --no-install-recommends --no-install-suggests -y wget ca-certificates git patch unzip bzip2 make gcc g++ libc-dev
 RUN wget -O /usr/bin/opam https://github.com/ocaml/opam/releases/download/2.1.5/opam-2.1.5-i686-linux && chmod 755 /usr/bin/opam
@@ -23,13 +23,13 @@ ENV OPAMCONFIRMLEVEL=unsafe-yes
 # Remove this line (and the base image pin above) if you want to test with the
 # latest versions.
 # taken from https://github.com/ocaml/opam-repository
-RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#d1a8bf040fbb2c81ddb2612f1a49a471a06083dc
+RUN opam init --disable-sandboxing -a --bare https://github.com/ocaml/opam-repository.git#3f468f0cfb62fbb1b8447c5369825ebe30cf60b0
 RUN opam switch create myswitch 4.14.1
 RUN opam exec -- opam install -y mirage opam-monorepo ocaml-solo5
 RUN mkdir /tmp/orb-build
 ADD config.ml /tmp/orb-build/config.ml
 WORKDIR /tmp/orb-build
 CMD opam exec -- sh -exc 'mirage configure -t xen --extra-repos=\
-opam-overlays:https://github.com/dune-universe/opam-overlays.git#91a371754a2c9f4febbb6c7bb039649ad49a3c13,\
-mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#05f1c1823d891ce4d8adab91f5db3ac51d86dc0b \
---allocation-policy=best-fit && make depend && make tar'
+opam-overlays:https://github.com/dune-universe/opam-overlays.git#4e75ee36715b27550d5bdb87686bb4ae4c9e89c4,\
+mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#797cb363df3ff763c43c8fbec5cd44de2878757e \
+&& make depend && make tar'

--- a/build-with.sh
+++ b/build-with.sh
@@ -20,5 +20,5 @@ $builder build -t qubes-mirage-firewall .
 echo Building Firewall...
 $builder run --rm -i -v `pwd`:/tmp/orb-build:Z qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 2c3f68f49afdeaeedd2c03f8ef6d30d6bb4d6306bda0a1ff40f95f440a90034c"
+echo "SHA2 last known: c93e6fca1ff5edb4acc1b726cbca92c1981412f73552bf07aaaa92ba7a270d02"
 echo "(hashes should match for released versions)"

--- a/config.ml
+++ b/config.ml
@@ -1,3 +1,4 @@
+(* mirage >= 4.5.0 *)
 (* Copyright (C) 2017, Thomas Leonard <thomas.leonard@unikernel.com>
    See the README file for details. *)
 
@@ -5,33 +6,27 @@
 
 open Mirage
 
-let table_size =
-  let info = Key.Arg.info
-      ~doc:"The number of NAT entries to allocate."
-      ~docv:"ENTRIES" ["nat-table-size"]
-  in
-  let key = Key.Arg.opt ~stage:`Both Key.Arg.int 5_000 info in
-  Key.create "nat_table_size" key
+let nat_table_size = runtime_arg ~pos:__POS__ "Unikernel.nat_table_size"
 
 let main =
-  foreign
-    ~keys:[Key.v table_size]
+    main
+    ~runtime_args:[ nat_table_size; ]
     ~packages:[
       package "vchan" ~min:"4.0.2";
       package "cstruct";
       package "astring";
       package "tcpip" ~min:"3.7.0";
-      package ~min:"2.3.0" ~sublibs:["mirage"] "arp";
-      package ~min:"3.0.0" "ethernet";
+      package "arp" ~min:"2.3.0" ~sublibs:["mirage"];
+      package "ethernet" ~min:"3.0.0";
       package "shared-memory-ring" ~min:"3.0.0";
-      package ~min:"2.1.2" "netchannel";
+      package "netchannel" ~min:"2.1.2";
       package "mirage-net-xen";
       package "ipaddr" ~min:"5.2.0";
       package "mirage-qubes" ~min:"0.9.1";
-      package ~min:"3.0.1" "mirage-nat";
+      package "mirage-nat" ~min:"3.0.1";
       package "mirage-logs";
       package "mirage-xen" ~min:"8.0.0";
-      package ~min:"6.4.0" "dns-client";
+      package "dns-client" ~min:"6.4.0";
       package "pf-qubes";
     ]
     "Unikernel.Main" (random @-> mclock @-> time @-> job)

--- a/memory_pressure.ml
+++ b/memory_pressure.ml
@@ -1,17 +1,16 @@
 (* Copyright (C) 2015, Thomas Leonard <thomas.leonard@unikernel.com>
    See the README file for details. *)
 
-open Lwt
-
 let src = Logs.Src.create "memory_pressure" ~doc:"Memory pressure monitor"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let wordsize_in_bytes = Sys.word_size / 8
+(* let wordsize_in_bytes = Sys.word_size / 8 *)
 
 let fraction_free stats =
   let { Xen_os.Memory.free_words; heap_words; _ } = stats in
   float free_words /. float heap_words
 
+(* unused now
 let meminfo stats =
   let { Xen_os.Memory.free_words; heap_words; _ } = stats in
   let mem_total = heap_words * wordsize_in_bytes in
@@ -26,6 +25,7 @@ let meminfo stats =
                   Cached: 0 kB\n\
                   SwapTotal: 0 kB\n\
                   SwapFree: 0 kB\n" (mem_total / 1024) (mem_free / 1024)
+*)
 
 let init () =
   Gc.full_major ()


### PR DESCRIPTION
Dear devs,
This PR wants to update to recent mirage API. In doing so it appears that `Memory.quick_stat()` reports wrong values (~~I haven't investigated why yet, and maybe it was present before, but now it goes lower than the limits in `memory_pressure.ml`~~ EDIT: There was a bad computation in `ocaml-solo5` again):
```
Memory.quick_stat() INF [memory_pressure] Writing meminfo: free 11MiB / 27MiB (39.99 %)
Memory.stat() INF [memory_pressure] Writing meminfo: free 19MiB / 27MiB (70.31 %)
```
~~With wrong values, the firewall starts to drop packets (`Memory_critical` being returned by `Memory_pressure.status()`). So I've replaced `Memory.quick_stat()` with `Memory.stat()`, but this is at the cost of going through the whole heap and `Memory_pressure.status` calls it for each packets. But I'd rather the firewall be slower than unusable :)~~

~~Going further will need to dive more into `ocaml-solo5/nolibc/malloc.i` as the bug seems to come from there but the code is really hard :'(~~
Best,