### PR TITLE
allow the firewall to use the router for dns requests (in rules)

### DIFF
--- a/dispatcher.ml
+++ b/dispatcher.ml
@@ -446,14 +446,14 @@ struct
                  clients := !clients |> Dao.VifMap.add key cleanup)))
 
   let send_dns_client_query t ~src_port ~dst ~dst_port buf =
-    match t with
+    match t.uplink with
     | None ->
         Log.err (fun f -> f "No uplink interface");
         Lwt.return (Error (`Msg "failure"))
-    | Some t -> (
+    | Some uplink -> (
         Lwt.catch
           (fun () ->
-            U.write ~src_port ~dst ~dst_port t.udp buf >|= function
+            U.write ~src_port ~dst ~dst_port uplink.udp buf >|= function
             | Error s ->
                 Log.err (fun f -> f "error sending udp packet: %a" U.pp_error s);
                 Error (`Msg "failure")

--- a/unikernel.ml
+++ b/unikernel.ml
@@ -103,7 +103,7 @@ module Main (R : Mirage_random.S)(Clock : Mirage_clock.MCLOCK)(Time : Mirage_tim
       ~uplink:None
     in
 
-    let send_dns_query = Dispatcher.send_dns_client_query None in
+    let send_dns_query = Dispatcher.send_dns_client_query router in
     let dns_mvar = Lwt_mvar.create_empty () in
     let nameservers = `Udp, [ config.Dao.dns, 53 ; config.Dao.dns2, 53 ] in
     let dns_client = Dns_client.create ~nameservers (router, send_dns_query, dns_mvar) in


### PR DESCRIPTION
This PR fixes a DNS issue that was onboarded in the last release. The DNS client of the firewall was not correctly configured, leading qmf unable to resolve rules with domain names. (fix is confirmed by @neoniobium at https://forum.qubes-os.org/t/mirage-firewall-0-9-0-released/26030/11)
I didn't updated the hashsum in this PR as I think this PR and #193 can both be merged and then we can cut a release with the final hashsum :)