### PR TITLE
Use Lwt.Syntax and avoid some >>= fun () patterns

### DIFF
--- a/build-with.sh
+++ b/build-with.sh
@@ -20,5 +20,5 @@ $builder build -t qubes-mirage-firewall .
 echo Building Firewall...
 $builder run --rm -i -v `pwd`:/tmp/orb-build:Z qubes-mirage-firewall
 echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 4b1f743bf4540bc8a9366cf8f23a78316e4f2d477af77962e50618753c4adf10"
+echo "SHA2 last known: 2392386d9056b17a648f26b0c5d1c72b93f8a197964c670b2b45e71707727317"
 echo "(hashes should match for released versions)"

--- a/dao.ml
+++ b/dao.ml
@@ -81,7 +81,7 @@ let vifs client domid =
           let get_client_ip () =
             let* str = Xen_os.Xs.read handle (Fmt.str "%s/%d/ip" path device_id) in
             let client_ip = List.hd (String.split_on_char ' ' str) in
-            (* XXX(dinosaure): it's safe to use [List.hd] here,
+            (* NOTE(dinosaure): it's safe to use [List.hd] here,
                [String.split_on_char] can not return an empty list. *)
             Lwt.return_some (vif, Ipaddr.V4.of_string_exn client_ip)
           in

--- a/dao.ml
+++ b/dao.ml
@@ -81,7 +81,8 @@ let vifs client domid =
           let get_client_ip () =
             let* str = Xen_os.Xs.read handle (Fmt.str "%s/%d/ip" path device_id) in
             let client_ip = List.hd (String.split_on_char ' ' str) in
-            Lwt.return_some (vif, Ipaddr.V4.of_string_exn client_ip) in
+            Lwt.return_some (vif, Ipaddr.V4.of_string_exn client_ip)
+          in
           Lwt.catch get_client_ip @@ function
           | Xs_protocol.Enoent _ -> Lwt.return_none
           | Ipaddr.Parse_error (msg, client_ip) ->
@@ -91,8 +92,10 @@ let vifs client domid =
           | exn ->
             Log.err (fun f -> f "Error getting IP address of %a: %s"
               ClientVif.pp vif (Printexc.to_string exn));
-            Lwt.return_none in
-      Lwt_list.filter_map_p ip_of_vif devices in
+            Lwt.return_none
+      in
+      Lwt_list.filter_map_p ip_of_vif devices
+    in
     Xen_os.Xs.immediate client vifs_of_domain
 
 let watch_clients fn =

--- a/dao.ml
+++ b/dao.ml
@@ -81,6 +81,8 @@ let vifs client domid =
           let get_client_ip () =
             let* str = Xen_os.Xs.read handle (Fmt.str "%s/%d/ip" path device_id) in
             let client_ip = List.hd (String.split_on_char ' ' str) in
+            (* XXX(dinosaure): it's safe to use [List.hd] here,
+               [String.split_on_char] can not return an empty list. *)
             Lwt.return_some (vif, Ipaddr.V4.of_string_exn client_ip)
           in
           Lwt.catch get_client_ip @@ function

--- a/dao.ml
+++ b/dao.ml
@@ -80,7 +80,7 @@ let vifs client domid =
           let vif = { ClientVif.domid; device_id } in
           let get_client_ip () =
             let* str = Xen_os.Xs.read handle (Fmt.str "%s/%d/ip" path device_id) in
-            let[@warning "-8"] client_ip :: _ = String.split_on_char ' ' str in
+            let client_ip = List.hd (String.split_on_char ' ' str) in
             Lwt.return_some (vif, Ipaddr.V4.of_string_exn client_ip) in
           Lwt.catch get_client_ip @@ function
           | Xs_protocol.Enoent _ -> Lwt.return_none

--- a/dao.ml
+++ b/dao.ml
@@ -113,7 +113,7 @@ let watch_clients fn =
     end >>= fun items ->
     Xen_os.Xs.make () >>= fun xs ->
     Lwt_list.map_p (vifs xs) items >>= fun items ->
-    fn (List.concat items |> VifMap.of_list);
+    fn (List.concat items |> VifMap.of_list) >>= fun () ->
     (* Wait for further updates *)
     Lwt.fail Xs_protocol.Eagain
   )

--- a/dao.mli
+++ b/dao.mli
@@ -15,7 +15,7 @@ module VifMap : sig
   val find : key -> 'a t -> 'a option
 end
 
-val watch_clients : (Ipaddr.V4.t VifMap.t -> unit) -> 'a Lwt.t
+val watch_clients : (Ipaddr.V4.t VifMap.t -> unit Lwt.t) -> 'a Lwt.t
 (** [watch_clients fn] calls [fn clients] with the list of backend clients
     in XenStore, and again each time XenStore updates. *)
 

--- a/dispatcher.ml
+++ b/dispatcher.ml
@@ -447,7 +447,7 @@ struct
         let* cleanup = add_client get_ts dns_client dns_servers ~router key ipaddr qubesDB in
         Log.debug (fun f -> f "client %a arrived" Dao.ClientVif.pp key);
         clients := Dao.VifMap.add key cleanup !clients;
-        go seq 
+        go seq
       | Some (_, seq) -> go seq
     in
     go (Dao.VifMap.to_seq new_set)

--- a/dispatcher.ml
+++ b/dispatcher.ml
@@ -17,8 +17,6 @@ struct
   module I = Static_ipv4.Make (R) (Clock) (UplinkEth) (Arp)
   module U = Udp.Make (I) (R)
 
-  let clients : Cleanup.t Dao.VifMap.t ref = ref Dao.VifMap.empty
-
   class client_iface eth ~domid ~gateway_ip ~client_ip client_mac : client_link
     =
     let log_header = Fmt.str "dom%d:%a" domid Ipaddr.V4.pp client_ip in
@@ -344,11 +342,12 @@ struct
 
   (** Connect to a new client's interface and listen for incoming frames and firewall rule changes. *)
   let add_vif get_ts { Dao.ClientVif.domid; device_id } dns_client dns_servers
-      ~client_ip ~router ~cleanup_tasks qubesDB =
-    Netback.make ~domid ~device_id >>= fun backend ->
+      ~client_ip ~router ~cleanup_tasks qubesDB () =
+    let open Lwt.Syntax in
+    let* backend = Netback.make ~domid ~device_id in
     Log.info (fun f ->
         f "Client %d (IP: %s) ready" domid (Ipaddr.V4.to_string client_ip));
-    ClientEth.connect backend >>= fun eth ->
+    let* eth = ClientEth.connect backend in
     let client_mac = Netback.frontend_mac backend in
     let client_eth = router.clients in
     let gateway_ip = Client_eth.client_gw client_eth in
@@ -404,46 +403,54 @@ struct
         (function Lwt.Canceled -> Lwt.return_unit | e -> Lwt.fail e)
     in
     Cleanup.on_cleanup cleanup_tasks (fun () -> Lwt.cancel listener);
-    Lwt.pick [ qubesdb_updater; listener ]
+    (* XXX(dinosaure): [qubes_updater] and [listener] can be forgotten, our [cleanup_task]
+       will cancel them if the client is disconnected. *)
+    Lwt.async (fun () -> Lwt.pick [ qubesdb_updater; listener ]);
+    Lwt.return_unit
 
   (** A new client VM has been found in XenStore. Find its interface and connect to it. *)
   let add_client get_ts dns_client dns_servers ~router vif client_ip qubesDB =
+    let open Lwt.Syntax in
     let cleanup_tasks = Cleanup.create () in
     Log.info (fun f ->
         f "add client vif %a with IP %a" Dao.ClientVif.pp vif Ipaddr.V4.pp
           client_ip);
-    Lwt.async (fun () ->
-        Lwt.catch
-          (fun () ->
-            add_vif get_ts vif dns_client dns_servers ~client_ip ~router
-              ~cleanup_tasks qubesDB)
-          (fun ex ->
-            Log.warn (fun f ->
-                f "Error with client %a: %s" Dao.ClientVif.pp vif
-                  (Printexc.to_string ex));
-            Lwt.return_unit));
-    cleanup_tasks
+    let* () =
+      Lwt.catch (add_vif get_ts vif dns_client dns_servers ~client_ip ~router
+          ~cleanup_tasks qubesDB)
+      @@ fun exn ->
+        Log.warn (fun f ->
+          f "Error with client %a: %s" Dao.ClientVif.pp vif
+            (Printexc.to_string exn));
+        Lwt.return_unit
+    in
+    Lwt.return cleanup_tasks
 
   (** Watch XenStore for notifications of new clients. *)
   let wait_clients get_ts dns_client dns_servers qubesDB router =
-    Dao.watch_clients (fun new_set ->
-        (* Check for removed clients *)
-        !clients
-        |> Dao.VifMap.iter (fun key cleanup ->
-               if not (Dao.VifMap.mem key new_set) then (
-                 clients := !clients |> Dao.VifMap.remove key;
-                 Log.info (fun f -> f "client %a has gone" Dao.ClientVif.pp key);
-                 Cleanup.cleanup cleanup));
-        (* Check for added clients *)
-        new_set
-        |> Dao.VifMap.iter (fun key ip_addr ->
-               if not (Dao.VifMap.mem key !clients) then (
-                 let cleanup =
-                   add_client get_ts dns_client dns_servers ~router key ip_addr
-                     qubesDB
-                 in
-                 Log.debug (fun f -> f "client %a arrived" Dao.ClientVif.pp key);
-                 clients := !clients |> Dao.VifMap.add key cleanup)))
+    let open Lwt.Syntax in
+    let clients : Cleanup.t Dao.VifMap.t ref = ref Dao.VifMap.empty in
+    Dao.watch_clients @@ fun new_set ->
+    (* Check for removed clients *)
+    let clean_up_clients key cleanup =
+      if not (Dao.VifMap.mem key new_set) then begin
+        clients := !clients |> Dao.VifMap.remove key;
+        Log.info (fun f -> f "client %a has gone" Dao.ClientVif.pp key);
+        Cleanup.cleanup cleanup
+      end
+    in
+    Dao.VifMap.iter clean_up_clients !clients;
+    (* Check for added clients *)
+    let rec go seq = match Seq.uncons seq with
+      | None -> Lwt.return_unit
+      | Some ((key, ipaddr), seq) when not (Dao.VifMap.mem key !clients) ->
+        let* cleanup = add_client get_ts dns_client dns_servers ~router key ipaddr qubesDB in
+        Log.debug (fun f -> f "client %a arrived" Dao.ClientVif.pp key);
+        clients := Dao.VifMap.add key cleanup !clients;
+        go seq 
+      | Some (_, seq) -> go seq
+    in
+    go (Dao.VifMap.to_seq new_set)
 
   let send_dns_client_query t ~src_port ~dst ~dst_port buf =
     match t.uplink with

--- a/dispatcher.ml
+++ b/dispatcher.ml
@@ -403,7 +403,7 @@ struct
         (function Lwt.Canceled -> Lwt.return_unit | e -> Lwt.fail e)
     in
     Cleanup.on_cleanup cleanup_tasks (fun () -> Lwt.cancel listener);
-    (* XXX(dinosaure): [qubes_updater] and [listener] can be forgotten, our [cleanup_task]
+    (* NOTE(dinosaure): [qubes_updater] and [listener] can be forgotten, our [cleanup_task]
        will cancel them if the client is disconnected. *)
     Lwt.async (fun () -> Lwt.pick [ qubesdb_updater; listener ]);
     Lwt.return_unit

--- a/fw_utils.ml
+++ b/fw_utils.ml
@@ -3,14 +3,6 @@
 
 (** General utility functions. *)
 
-module IpMap = struct
-  include Map.Make(Ipaddr.V4)
-  let find x map =
-    try Some (find x map)
-    with Not_found -> None
-    | _ -> Logs.err( fun f -> f "uncaught exception in find...%!"); None
-end
-
 (** An Ethernet interface. *)
 class type interface = object
   method my_mac : Macaddr.t


### PR DESCRIPTION
This little commit takes the advantage of `let*` to replace some parts of the code. In my opinion (feel free to take it in account), the code is more readable than before. About the `vifs` function, I take the advantage that `String.split_on_char` can not return an empty list according to the documentation: we can pattern-match with `[@warning "-8"]` or use `List.hd`.