### PR TITLE
Update the salt script + releases files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: ./build-with.sh docker
 
-      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen) = $(cat qubes-firewall.sha256) ]; then echo "SHA256 MATCHES"; else exit 42; fi'
+      - run: sh -exc 'if [ "$(sha256sum dist/qubes-firewall.xen)" = "$(cat qubes-firewall.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: ./build-with.sh docker
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: mirage-firewall.tar.bz2
-          path: mirage-firewall.tar.bz2
+          name: qubes-firewall.xen
+          path: qubes-firewall.xen

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: ./build-with.sh docker
 
-      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen | cut -d " " -f 1) = $(grep "SHA2 last known" build-with.sh | rev | cut -d ":" -f 1 | rev | cut -d "\"" -f 1 | tr -d " ") ]; then echo "SHA256 MATCHES"; else exit 42; fi'
+      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen) = $(cat qubes-firewall.sha256) ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: mirage-firewall.tar.bz2
-          path: mirage-firewall.tar.bz2
+          name: qubes-firewall.xen
+          path: qubes-firewall.xen

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: ./build-with.sh podman
 

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: ./build-with.sh podman
 
-      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen | cut -d " " -f 1) = $(grep "SHA2 last known" build-with.sh | rev | cut -d ":" -f 1 | rev | cut -d "\"" -f 1 | tr -d " ") ]; then echo "SHA256 MATCHES"; else exit 42; fi'
+      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen) = $(cat qubes-firewall.sha256) ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: ./build-with.sh podman
 
-      - run: sh -exc 'if [ $(sha256sum dist/qubes-firewall.xen) = $(cat qubes-firewall.sha256) ]; then echo "SHA256 MATCHES"; else exit 42; fi'
+      - run: sh -exc 'if [ "$(sha256sum dist/qubes-firewall.xen)" = "$(cat qubes-firewall.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ WORKDIR /tmp/orb-build
 CMD opam exec -- sh -exc 'mirage configure -t xen --extra-repos=\
 opam-overlays:https://github.com/dune-universe/opam-overlays.git#4e75ee36715b27550d5bdb87686bb4ae4c9e89c4,\
 mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git#797cb363df3ff763c43c8fbec5cd44de2878757e \
-&& make depend && make tar'
+&& make depend && make unikernel'

--- a/Makefile.user
+++ b/Makefile.user
@@ -1,13 +1,8 @@
-tar: build
-	rm -rf _build/mirage-firewall
-	mkdir _build/mirage-firewall
+unikernel: build
 	cp dist/qubes-firewall.xen dist/qubes-firewall.xen.debug
 	strip dist/qubes-firewall.xen
-	cp dist/qubes-firewall.xen _build/mirage-firewall/vmlinuz
-	touch _build/mirage-firewall/modules.img
-	cat /dev/null | gzip -n > _build/mirage-firewall/initramfs
-	tar cjf mirage-firewall.tar.bz2 -C _build --mtime=./build-with.sh mirage-firewall
-	sha256sum mirage-firewall.tar.bz2 > mirage-firewall.sha256
+	cp dist/qubes-firewall.xen .
+	sha256sum qubes-firewall.xen
 
 fetchmotron: qubes_firewall.xen
 	test-mirage qubes_firewall.xen mirage-fw-test &

--- a/build-with.sh
+++ b/build-with.sh
@@ -19,6 +19,7 @@ echo Building $builder image with dependencies..
 $builder build -t qubes-mirage-firewall .
 echo Building Firewall...
 $builder run --rm -i -v `pwd`:/tmp/orb-build:Z qubes-mirage-firewall
-echo "SHA2 of build:   $(sha256sum ./dist/qubes-firewall.xen)"
-echo "SHA2 last known: 78a1ee52574b9a4fc5eda265922bcbcface90f7c43ed7a68dc8e201a2ac0a7dc"
-echo "(hashes should match for released versions)"
+echo "SHA2 of build:     $(sha256sum ./dist/qubes-firewall.xen | cut -d' ' -f1)"
+echo "SHA2 current head: $(cat qubes-firewall.sha256 | cut -d' ' -f1)"
+echo "SHA2 last release: $(cat qubes-firewall-release.sha256 | cut -d' ' -f1)"
+echo "(hashes should match for head versions)"

--- a/qubes-firewall-release.sha256
+++ b/qubes-firewall-release.sha256
@@ -1,0 +1,1 @@
+78a1ee52574b9a4fc5eda265922bcbcface90f7c43ed7a68dc8e201a2ac0a7dc  dist/qubes-firewall.xen

--- a/qubes-firewall.sha256
+++ b/qubes-firewall.sha256
@@ -1,0 +1,1 @@
+78a1ee52574b9a4fc5eda265922bcbcface90f7c43ed7a68dc8e201a2ac0a7dc  dist/qubes-firewall.xen


### PR DESCRIPTION
This PR wants to solve #200 and emphasises the separation of sha256 for released versions and for the current version of head. This way we can push commits on top of head, continue to ensure reproducible builds, and also keep something to compare the shasum of the released version. The PR process will need updating `qubes-firewall.sha256`, and the release process need to copy this file into `qubes-firewall-release.sha256`. WDYT?

I'm unsure whether the salt script has been updated correctly and I'll have to wait for the next version to fix any issues.
