### PR TITLE
update gh action upload artifact

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sh -exc 'if [ "$(sha256sum dist/qubes-firewall.xen)" = "$(cat qubes-firewall.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qubes-firewall.xen
           path: qubes-firewall.xen

--- a/.github/workflows/podman.yml
+++ b/.github/workflows/podman.yml
@@ -26,7 +26,7 @@ jobs:
       - run: sh -exc 'if [ "$(sha256sum dist/qubes-firewall.xen)" = "$(cat qubes-firewall.sha256)" ]; then echo "SHA256 MATCHES"; else exit 42; fi'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qubes-firewall.xen
           path: qubes-firewall.xen


### PR DESCRIPTION
Hello,
`actions/upload-artifact@v3` is deprecated since 30 Nov. 2024 (see https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact), bump to v4.