### PR TITLE
Fallback netvm mac

### DIFF
--- a/qubes-firewall.sha256
+++ b/qubes-firewall.sha256
@@ -1,1 +1,1 @@
-b78d6711b502f8babcc5c4083b0352b78be8e8a6bef044189ce7a00e6e564612  dist/qubes-firewall.xen
+0c3c2c0e62a834112c69d7cddc5dd6f70ecb93afa988768fb860ed26e423b1f8  dist/qubes-firewall.xen


### PR DESCRIPTION
Dear developpers,
This PR is what I had in mind to solve #212 , the fix is confirmed by the user that reported the issue with mullvad.
When searching in the QubesOS repository I got several occurrences of that precise mac address (see https://github.com/search?q=org%3AQubesOS%20fe%3Aff%3Aff%3Aff%3Aff%3Aff&type=code).

Just in case /cc @marmarek or @DemiMarie to confirm there is no security issue to fall back to that mac address in case our netvm does not reply to arp request ?