### PR TITLE
Fix HVM clients AppVMs

### DIFF
--- a/qubes-firewall.sha256
+++ b/qubes-firewall.sha256
@@ -1,1 +1,1 @@
-ac049069b35f786fa11b18a2261d7dbecd588301af0363ef6888ec9d924dc989  dist/qubes-firewall.xen
+4a507a4306e12a55b5bb8b5cb41080dc5f74ff4d701bbfecefefdc74f8580a86  dist/qubes-firewall.xen


### PR DESCRIPTION
This PR wants to handle the case of HVM AppVMs.

HVM clients have two clients interfaces (appvm and appvm-dm), and therefore the unikernel see two vif interfaces. But only one should be active at the same time (one in state 4 "initialized" and the other in state 2 "initializing") and which one depends on the drivers of the system inside the AppVM. So to handle all cases we perform an initialization for both, but the client driver should theoritically only complete the initialization process for one of them (and here we catch the exception for the other).
